### PR TITLE
Fix typo in Eigen symlink command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo apt install libeigen3-dev
 ```
 and then create a symlink so that ORB_SLAM3 can find it:
 ```bash
-sudo ln -s /usr/include/eigen3/Eigen/ /usr/include/Eigen/
+sudo ln -s /usr/include/eigen3/Eigen/ /usr/include/Eigen
 ```
 
 Next, cd into the ORB_SLAM3 directory and run the ```build.sh``` script. Make sure the


### PR DESCRIPTION
As the docs are right now, it is trying to create the symlink in a nonexistent folder `/usr/include/Eigen` instead of creating a symlink at that path. If you don't already have a folder there you'll get a `No such file or directory` error. Just removing the trailing slash fixes this.